### PR TITLE
Reapplying changes for the urlimage parameter

### DIFF
--- a/karuta/xsl/xmlportfolio2fo.xsl
+++ b/karuta/xsl/xmlportfolio2fo.xsl
@@ -13,6 +13,7 @@
 <xsl:param name="url"/>
 <xsl:param name="ppath"/>
 <xsl:param name="url-appli"/>
+<xsl:param name="urlimage"/>
 
 <xsl:include href="xmlportfolio2fo_base.xsl"/>
 

--- a/karuta/xsl/xmlportfolio2fo_base.xsl
+++ b/karuta/xsl/xmlportfolio2fo_base.xsl
@@ -428,7 +428,7 @@
 	<xsl:param name="width-print"/>
 
 	<xsl:variable name='src'>
-		<xsl:value-of select="$url"/>/resources/resource/file/<xsl:value-of select="./@contextid"/>?lang=<xsl:value-of select="$lang"/>&amp;size=L
+		<xsl:value-of select="$urlimage"/>/resources/resource/file/<xsl:value-of select="./@contextid"/>?lang=<xsl:value-of select="$lang"/>&amp;size=L
 	</xsl:variable>
 	<xsl:variable name='width'>
 		<xsl:choose>


### PR DESCRIPTION
Adding parameter for XSL redirection. Some network configuration need it.
On the backend side it will use the default value from backendserver if not set.

Related backend commit change: https://github.com/karutaproject/karuta-backend/commit/d1bef2d6478f9874f003194332a18e86dfe98de6