### PR TITLE
Update karuta.htm

### DIFF
--- a/WebContent/application/htm/karuta.htm
+++ b/WebContent/application/htm/karuta.htm
@@ -58,7 +58,7 @@
 	<body>
 		<script defer>
 			if (typeof specificmenus!='undefined' &&  specificmenus)
-				loadJS("../js/specificmenu.js");
+				loadJS("../js/specific.js");
 			window.onload = function() {
 			};
 		</script>


### PR DESCRIPTION
`specificmenu.js` a été remplacé par `specific.js` dans la version 2.4.1. Il faudrait aussi revoir le bien-fondé du ` var specificmenus = true;` dans `_init.js` car il y a un risque d'erreur ("`g_execbatch is not defined`") dans `list.js` et `batch.js` si `specificmenus = false;` 